### PR TITLE
Fixed keycloak env variables

### DIFF
--- a/deployments/helm/keycloak-k8s-local/templates/05_keycloak.yml
+++ b/deployments/helm/keycloak-k8s-local/templates/05_keycloak.yml
@@ -56,21 +56,16 @@ spec:
               value: "true"
             - name: KC_LOG_LEVEL
               value: INFO
-            - name: DB_VENDOR
-              value: POSTGRES
-            - name: DB_ADDR
-              value: "{{ .Values.deployments.postgres.service.name }}"
-            - name: DB_DATABASE
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .Values.secrets.postgres.name }}"
-                  key: POSTGRES_DB
-            - name: DB_USER
+            - name: KC_DB
+              value: postgres
+            - name: KC_DB_URL
+              value: "jdbc:postgresql://{{ .Values.deployments.postgres.service.name }}/{{ .Values.deployments.postgres.db.name }}"
+            - name: KC_DB_USERNAME
               valueFrom:
                 secretKeyRef:
                   name: "{{ .Values.secrets.postgres.name }}"
                   key: POSTGRES_USER
-            - name: DB_PASSWORD
+            - name: KC_DB_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: "{{ .Values.secrets.postgres.name }}"

--- a/deployments/manual/05_keycloak.yml
+++ b/deployments/manual/05_keycloak.yml
@@ -56,21 +56,21 @@ spec:
           value: "true"
         - name: KC_LOG_LEVEL
           value: INFO
-        - name: DB_VENDOR
-          value: POSTGRES
-        - name: DB_ADDR
+        - name: KC_DB
           value: postgres
-        - name: DB_DATABASE
+        - name: POSTGRES_DB
           valueFrom:
             secretKeyRef:
               name: postgres-credentials
               key: POSTGRES_DB
-        - name: DB_USER
+        - name: KC_DB_URL
+          value: jdbc:postgresql://postgres/$(POSTGRES_DB)
+        - name: KC_DB_USERNAME
           valueFrom:
             secretKeyRef:
               name: postgres-credentials
               key: POSTGRES_USER
-        - name: DB_PASSWORD
+        - name: KC_DB_PASSWORD
           valueFrom:
             secretKeyRef:
               name: postgres-credentials


### PR DESCRIPTION
Fixes #1 

Environment variables in Keycloak are fixed by this patch, so that Keycloak knows how to connect to Postgres instance.